### PR TITLE
Introduce `next_start_time` for future game scheduling

### DIFF
--- a/contracts/prudent-pots/src/contract.rs
+++ b/contracts/prudent-pots/src/contract.rs
@@ -51,7 +51,15 @@ pub fn instantiate(
     REALLOCATION_FEE_POOL.save(deps.storage, &Uint128::zero())?;
 
     // Initialize game state and pots for the next game
-    prepare_next_game(deps, &env, Uint128::zero(), None, None, None)?;
+    prepare_next_game(
+        deps,
+        &env,
+        Uint128::zero(),
+        None,
+        None,
+        None,
+        msg.next_game_start,
+    )?;
 
     Ok(Response::new()
         .add_attribute("method", "instantiate")
@@ -76,12 +84,14 @@ pub fn execute(
         ExecuteMsg::GameEnd {
             raffle_cw721_token_id,
             raffle_cw721_token_addr,
+            next_game_start,
         } => game_end(
             deps,
             env,
             info,
             raffle_cw721_token_id,
             raffle_cw721_token_addr,
+            next_game_start,
         ),
     }
 }

--- a/contracts/prudent-pots/src/error.rs
+++ b/contracts/prudent-pots/src/error.rs
@@ -45,6 +45,9 @@ pub enum ContractError {
     #[error("Raffle NFT specified is invalid.")]
     InvalidRaffleNft {},
 
+    #[error("The next game start time is invalid.")]
+    InvalidNextGameStart {},
+
     #[error("Expected a CW721 token transfer but none was received.")]
     Cw721TokenNotReceived {},
 

--- a/contracts/prudent-pots/src/error.rs
+++ b/contracts/prudent-pots/src/error.rs
@@ -27,6 +27,9 @@ pub enum ContractError {
     #[error("The reallocations limit has been reached for your address.")]
     ReallocationsLimitReached {},
 
+    #[error("This action cannot be performed as the game has not started yet.")]
+    GameNotStarted {},
+
     #[error("This action cannot be performed as the game has already ended.")]
     GameAlreadyEnded {},
 

--- a/contracts/prudent-pots/src/execute.rs
+++ b/contracts/prudent-pots/src/execute.rs
@@ -220,6 +220,11 @@ pub fn game_end(
     validate_game_end_time(deps.storage, &env)?;
     validate_is_contract_admin_game_end(deps.storage, &deps.querier, &env, &info.sender)?;
 
+    // if passed, it should be in the future
+    if next_game_start.is_some() && next_game_start.unwrap() <= env.block.time.seconds() {
+        return Err(ContractError::InvalidNextGameStart {});
+    }
+
     // Ensure both or neither options are provided
     if new_raffle_cw721_id.is_some() != new_raffle_cw721_addr.is_some() {
         return Err(ContractError::InvalidRaffleNft {});

--- a/contracts/prudent-pots/src/execute.rs
+++ b/contracts/prudent-pots/src/execute.rs
@@ -214,6 +214,7 @@ pub fn game_end(
     info: MessageInfo,
     new_raffle_cw721_id: Option<String>,
     new_raffle_cw721_addr: Option<String>,
+    next_game_start: Option<u64>,
 ) -> Result<Response, ContractError> {
     validate_game_end_time(deps.storage, &env)?;
     validate_is_contract_admin_game_end(deps.storage, &deps.querier, &env, &info.sender)?;
@@ -283,6 +284,7 @@ pub fn game_end(
         process_raffle_winner_resp.new_raffle_cw721_id,
         process_raffle_winner_resp.new_raffle_cw721_addr,
         Some(process_raffle_winner_resp.new_raffle_denom_amount),
+        next_game_start,
     )?;
 
     Ok(Response::new()

--- a/contracts/prudent-pots/src/helpers/game_end.rs
+++ b/contracts/prudent-pots/src/helpers/game_end.rs
@@ -31,13 +31,15 @@ pub fn prepare_next_game(
     raffle_cw721_token_id: Option<String>,
     raffle_cw721_addr: Option<String>,
     raffle_denom_amount: Option<Uint128>,
+    next_game_start: Option<u64>, // this is intended as a unix timestamp in seconds that should replace the current timestamp, but should also be higher than the current timestamp
 ) -> Result<(u64, u64, u32), ContractError> {
     let config = GAME_CONFIG.load(deps.storage)?;
     let game_state = GAME_STATE.may_load(deps.storage)?.unwrap_or_default(); // may load due instantiate invoke
 
+    // TODO: finish the impl
     // Start the next game 1 second in the future
     let game_duration = config.game_duration;
-    let next_game_start = env.block.time.seconds();
+    let next_game_start = next_game_start.unwrap_or(env.block.time.seconds());
     let next_game_end = next_game_start + game_duration;
 
     // Validate game start and end times

--- a/contracts/prudent-pots/src/helpers/pot.rs
+++ b/contracts/prudent-pots/src/helpers/pot.rs
@@ -95,7 +95,7 @@ pub fn calculate_min_bid(
     // Calculate the current epoch based on the game's start time and duration
     let elapsed_time = current_timestamp
         .checked_sub(game_state.start_time)
-        .unwrap();
+        .unwrap_or_default(); // this could underflow due to a round scheduled in the future, so we unwrap default 0
     let current_epoch_count = elapsed_time
         .checked_div(game_config.game_duration_epoch)
         .unwrap();

--- a/contracts/prudent-pots/src/helpers/validate.rs
+++ b/contracts/prudent-pots/src/helpers/validate.rs
@@ -153,34 +153,17 @@ pub fn validate_pot_limit_not_exceeded(
 }
 
 // Helper to validate the game's end time and extend it if necessary during the round for allocations and reallocations
-pub fn validate_and_extend_game_time(
-    storage: &mut dyn Storage,
-    env: &Env,
-) -> Result<(), ContractError> {
-    let game_config = GAME_CONFIG.load(storage)?;
-    let mut game_state = GAME_STATE.load(storage)?;
+pub fn validate_game_time(storage: &mut dyn Storage, env: &Env) -> Result<(), ContractError> {
+    let game_state = GAME_STATE.load(storage)?;
 
     // Check if the game is not started yet
     if env.block.time.seconds().lt(&game_state.start_time) {
-        return Err(ContractError::GameAlreadyEnded {});
+        return Err(ContractError::GameNotStarted {});
     }
 
     // Check if the game has already ended
     if env.block.time.seconds().ge(&game_state.end_time) {
         return Err(ContractError::GameAlreadyEnded {});
-    }
-
-    // Calculate the remaining time
-    let remaining_time = game_state
-        .end_time
-        .checked_sub(env.block.time.seconds())
-        .unwrap();
-
-    // Extend the game time if the remaining time is less than or equal to game_config.game_extend
-    if remaining_time.le(&game_config.game_extend) {
-        game_state.end_time = env.block.time.seconds() + game_config.game_extend;
-        game_state.extend_count = game_state.extend_count.checked_add(1).unwrap();
-        GAME_STATE.save(storage, &game_state)?;
     }
 
     Ok(())
@@ -189,6 +172,11 @@ pub fn validate_and_extend_game_time(
 // Helper to validate the game's end time during game_end exeuction
 pub fn validate_game_end_time(storage: &dyn Storage, env: &Env) -> Result<(), ContractError> {
     let game_state = GAME_STATE.load(storage)?;
+
+    // Check if the game is not started yet
+    if env.block.time.seconds().lt(&game_state.start_time) {
+        return Err(ContractError::GameNotStarted {});
+    }
 
     // Check if the game is still active
     if env.block.time.seconds().lt(&game_state.end_time) {
@@ -213,4 +201,25 @@ pub fn validate_funds(funds: &[Coin], expected_denom: &str) -> Result<Uint128, C
     }
 
     Ok(total_amount)
+}
+
+// Helper to validate the game's end time and extend it if necessary during the round for allocations and reallocations
+pub fn extend_game_time(storage: &mut dyn Storage, env: &Env) -> Result<(), ContractError> {
+    let game_config = GAME_CONFIG.load(storage)?;
+    let mut game_state = GAME_STATE.load(storage)?;
+
+    // Calculate the remaining time
+    let remaining_time = game_state
+        .end_time
+        .checked_sub(env.block.time.seconds())
+        .unwrap();
+
+    // Extend the game time if the remaining time is less than or equal to game_config.game_extend
+    if remaining_time.le(&game_config.game_extend) {
+        game_state.end_time = env.block.time.seconds() + game_config.game_extend;
+        game_state.extend_count = game_state.extend_count.checked_add(1).unwrap();
+        GAME_STATE.save(storage, &game_state)?;
+    }
+
+    Ok(())
 }

--- a/contracts/prudent-pots/src/msg.rs
+++ b/contracts/prudent-pots/src/msg.rs
@@ -7,6 +7,7 @@ use crate::state::{GameConfig, GameState, Raffle, TokenAllocation};
 #[cw_serde]
 pub struct InstantiateMsg {
     pub config: GameConfig,
+    pub next_game_start: Option<u64>,
 }
 
 #[cw_serde]
@@ -40,6 +41,7 @@ pub enum ExecuteMsg {
     GameEnd {
         raffle_cw721_token_id: Option<String>,
         raffle_cw721_token_addr: Option<String>,
+        next_game_start: Option<u64>,
     },
 }
 

--- a/contracts/prudent-pots/src/tests/instantiate.rs
+++ b/contracts/prudent-pots/src/tests/instantiate.rs
@@ -40,6 +40,7 @@ pub mod tests {
             info.clone(),
             InstantiateMsg {
                 config: config.clone(),
+                next_game_start: None,
             },
         )
         .unwrap();

--- a/contracts/prudent-pots/src/tests/integration/allocate_tokens.rs
+++ b/contracts/prudent-pots/src/tests/integration/allocate_tokens.rs
@@ -10,8 +10,12 @@ use crate::ContractError;
 
 #[test]
 fn test_allocate_tokens_works() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(1, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        1,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     // Sending enough funds
     let info = mock_info("user1", &coins(1_000_000, DENOM_GAME));
@@ -32,8 +36,12 @@ fn test_allocate_tokens_works() {
 
 #[test]
 fn test_allocate_tokens_fails() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(1, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        1,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     // Sending too little funds
     let info = mock_info("user1", &coins(1, DENOM_GAME));
@@ -63,8 +71,12 @@ fn test_allocate_tokens_fails() {
 
 #[test]
 fn test_allocate_tokens_min_bet_works() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(1, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        1,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     // Contract started with 5 $DENOM and a min_pot_initial_allocation of 1.0 $DENOM.
     // Subsequently the minimum bet starts by 1.0 $DENOM with a 0.0 multiplier as we are still in the epoch 0.

--- a/contracts/prudent-pots/src/tests/integration/fixtures.rs
+++ b/contracts/prudent-pots/src/tests/integration/fixtures.rs
@@ -68,6 +68,7 @@ pub fn default_with_balances(
     num_users: u8,
     initial_balance: Vec<Coin>,
     raffle: Option<Raffle>,
+    next_game_start: Option<u64>,
 ) -> (App, Addr, Addr) {
     // Create a vector to hold the balances setup
     let mut balances = vec![(
@@ -128,6 +129,7 @@ pub fn default_with_balances(
                     decay_factor: Decimal::from_str("0.05").unwrap(),
                     reallocations_limit: 10,
                 },
+                next_game_start: None,
             };
             pp_addr = instantiate_pp(
                 &mut app,
@@ -188,6 +190,7 @@ pub fn default_with_balances(
                 ),
                 raffle.cw721_token_id,        // raffle nft prize
                 Some(cw721_addr.to_string()), // overriding the None passed from outside as contract wasnt instantiated yet
+                next_game_start,
             )
             .unwrap();
         }
@@ -207,6 +210,7 @@ pub fn default_with_balances(
                     decay_factor: Decimal::from_str("0.05").unwrap(),
                     reallocations_limit: 10,
                 },
+                next_game_start,
             };
             pp_addr = instantiate_pp(
                 &mut app,

--- a/contracts/prudent-pots/src/tests/integration/game_end.rs
+++ b/contracts/prudent-pots/src/tests/integration/game_end.rs
@@ -511,6 +511,27 @@ fn test_game_end_future_works() {
     // Game end, expect it to succeed, restart it in the future
     let info = mock_info(ADMIN_ADDRESS, &vec![]);
     let next_game_start = app.block_info().time.plus_seconds(GAME_EXTEND).seconds();
+    // try with wrong (in the past) next_game_start
+    game_end(
+        &mut app,
+        &pp_addr,
+        &info,
+        None,
+        None,
+        Some(next_game_start - (GAME_EXTEND + 1)),
+    )
+    .unwrap_err();
+    // try with wrong (in the present) next_game_start
+    game_end(
+        &mut app,
+        &pp_addr,
+        &info,
+        None,
+        None,
+        Some(next_game_start - GAME_EXTEND),
+    )
+    .unwrap_err();
+    // make it succeed
     game_end(&mut app, &pp_addr, &info, None, None, Some(next_game_start)).unwrap();
 
     // Game end, we expect it to fail as the game didnt start yet

--- a/contracts/prudent-pots/src/tests/integration/game_end.rs
+++ b/contracts/prudent-pots/src/tests/integration/game_end.rs
@@ -21,8 +21,12 @@ use super::{
 
 #[test]
 fn test_game_end_one_winner_simple_works() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(5, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        5,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     // Game state extend_count after
     let game_state: GameStateResponse = app
@@ -85,7 +89,7 @@ fn test_game_end_one_winner_simple_works() {
 
     // Game end and new raffles
     let info = mock_info(ADMIN_ADDRESS, &vec![]);
-    game_end(&mut app, &pp_addr, &info, None, None).unwrap();
+    game_end(&mut app, &pp_addr, &info, None, None, None).unwrap();
 
     // Get user balance after game_end
     let user5_balance_after = app.wrap().query_balance("user5", DENOM_GAME).unwrap();
@@ -161,6 +165,7 @@ fn test_game_end_one_winner_raffle_both_works() {
             cw721_addr: None, // this will be overridden by the fixture after cw721 contract instantiation
             denom_amount: Uint128::new(100_000_000u128),
         }),
+        None,
     );
 
     // Game state extend_count after
@@ -325,6 +330,7 @@ fn test_game_end_one_winner_raffle_both_works() {
         &info,
         Some("2".to_string()),
         Some(cw721_addr.to_string()),
+        None,
     )
     .unwrap();
 

--- a/contracts/prudent-pots/src/tests/integration/helpers.rs
+++ b/contracts/prudent-pots/src/tests/integration/helpers.rs
@@ -58,6 +58,7 @@ pub fn game_end(
     info: &MessageInfo,
     raffle_cw721_token_id: Option<String>,
     raffle_cw721_token_addr: Option<String>,
+    next_game_start: Option<u64>,
 ) -> Result<AppResponse, AnyError> {
     app.execute_contract(
         info.sender.clone(),
@@ -65,6 +66,7 @@ pub fn game_end(
         &ExecuteMsg::GameEnd {
             raffle_cw721_token_id,
             raffle_cw721_token_addr,
+            next_game_start,
         },
         &info.funds,
     )

--- a/contracts/prudent-pots/src/tests/integration/reallocate_tokens.rs
+++ b/contracts/prudent-pots/src/tests/integration/reallocate_tokens.rs
@@ -7,8 +7,12 @@ use crate::tests::integration::helpers::{allocate_tokens, reallocate_tokens};
 
 #[test]
 fn test_reallocate_tokens_works() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(1, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        1,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     let info = mock_info("user1", &coins(1_000_000, DENOM_GAME));
 

--- a/contracts/prudent-pots/src/tests/integration/update_config.rs
+++ b/contracts/prudent-pots/src/tests/integration/update_config.rs
@@ -9,8 +9,12 @@ use crate::tests::integration::helpers::update_config;
 
 #[test]
 fn test_update_config_works() {
-    let (mut app, pp_addr, _cw721_addr) =
-        default_with_balances(1, vec![coin(100_000_000u128, DENOM_GAME.to_string())], None);
+    let (mut app, pp_addr, _cw721_addr) = default_with_balances(
+        1,
+        vec![coin(100_000_000u128, DENOM_GAME.to_string())],
+        None,
+        None,
+    );
 
     // Update config as admin
     let res = update_config(

--- a/contracts/prudent-pots/src/tests/prepare_next_game.rs
+++ b/contracts/prudent-pots/src/tests/prepare_next_game.rs
@@ -35,16 +35,12 @@ mod tests {
 
         // Test case
 
-        prepare_next_game(deps.as_mut(), &env, Uint128::zero(), None, None, None).unwrap();
+        prepare_next_game(deps.as_mut(), &env, Uint128::zero(), None, None, None, None).unwrap();
 
         // Verify new GAME_STATE after running prepare next game
         let game_state = GAME_STATE.load(deps.as_mut().storage).unwrap();
         assert_eq!(game_state.start_time, env.block.time.seconds());
         assert_eq!(game_state.end_time, env.block.time.seconds() + 3600);
-
-        // @deprecated as now this is a game_end responsibility: Verify reallocation fee pool reset
-        // let reallocation_fee_pool = REALLOCATION_FEE_POOL.load(deps.as_mut().storage).unwrap();
-        // assert_eq!(reallocation_fee_pool, Uint128::zero());
 
         // TODO_FUTURE: PlayerAllocations reset assertion
 

--- a/frontend-common/mixin/game.js
+++ b/frontend-common/mixin/game.js
@@ -1,4 +1,4 @@
-import {mapActions, mapGetters, mapMutations} from "vuex";
+import { mapActions, mapGetters, mapMutations } from "vuex";
 
 const mxGame = {
   data() {
@@ -10,17 +10,35 @@ const mxGame = {
   computed: {
     ...mapGetters(['userAddress', 'gameState', "gameActivitySelectedRound"]),
 
+    isCountingDownToStart() {
+      if (!this.gameState) return null;
+      const startTime = this.gameState.start_time * 1000;
+      return this.currentTime < startTime;
+    },
+
     timeLeftSeconds() {
       if (!this.gameState) return null;
+      // take the start time
+      const startTime = this.gameState.start_time * 1000;
+      // take the end time
       const endTime = this.gameState.end_time * 1000;
-      const timeDiff = endTime - this.currentTime;
-      return timeDiff > 0 ? Math.floor(timeDiff / 1000) : 0;
+      const now = this.currentTime;
+      if (now < startTime) {
+        // we are before the start
+        return Math.floor((startTime - now) / 1000); // Countdown to start
+      } else if (now < endTime) {
+        // we are during the game
+        return Math.floor((endTime - now) / 1000); // Countdown to end
+      } else {
+        // the game finished and it hasnt been restarted/scheduled
+        return 0;
+      }
     },
 
     timeLeftHuman() {
       const timeDiff = this.timeLeftSeconds * 1000;
       if (timeDiff <= 0) {
-        return "0d 0h 0m 0s";
+        return "Time's up!";
       }
       const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
       const hours = Math.floor((timeDiff / (1000 * 60 * 60)) % 24);

--- a/frontend-common/store/index.js
+++ b/frontend-common/store/index.js
@@ -361,7 +361,6 @@ export default createStore({
         console.error("Querier is not initialized");
         return;
       }
-
       const data = await state.user.querier.queryContractSmart(
         process.env.VUE_APP_CONTRACT,
         {all_players_allocations: {}}
@@ -374,7 +373,6 @@ export default createStore({
         console.error("Querier is not initialized");
         return;
       }
-
       const data = await state.user.querier.queryContractSmart(
         process.env.VUE_APP_CONTRACT,
         {pots_state: {}}
@@ -387,7 +385,6 @@ export default createStore({
         console.error("Querier is not initialized");
         return;
       }
-
       const data = await state.user.querier.queryContractSmart(
         process.env.VUE_APP_CONTRACT,
         {winning_pots: {}}
@@ -400,7 +397,6 @@ export default createStore({
         console.error("Querier is not initialized");
         return;
       }
-
       const data = await state.user.querier.queryContractSmart(
         process.env.VUE_APP_CONTRACT,
         {bid_range: {address: state.user.address}}
@@ -413,7 +409,6 @@ export default createStore({
         console.error("Querier is not initialized");
         return;
       }
-
       const data = await state.user.querier.queryContractSmart(
         process.env.VUE_APP_CONTRACT,
         {reallocation_fee_pool: {}}

--- a/frontend-ms/src/components/Common/TimerComponent.vue
+++ b/frontend-ms/src/components/Common/TimerComponent.vue
@@ -3,7 +3,11 @@
     <img :src="imageTimer" alt="Timer" class="img-fluid"/>
 
     <div class="timer-card pt-5">
-      <h2 class="counter text-pp-color-3 mb-0 mb-md-4">{{ timeLeftSeconds ? timeLeftHuman : "Time's up!" }}</h2>
+      <h3 class="counter text-pp-color-3 mb-0 mb-md-4">
+        <span v-if="isCountingDownToStart">Next round in:<br></span>
+        <span v-else>Game ends in:<br></span>
+        {{ timeLeftHuman }}
+      </h3>
 
       <h5 class="text-pp-color-3 text-end">Extends: {{ gameState.extend_count.toString() || 'N/D' }}</h5>
     </div>
@@ -42,12 +46,12 @@ export default {
     transform: translate(-50%, -50%);
     width: 47.5%;
 
-    h2 {
+    h3, h5 {
       font-family: "Reddit Mono", monospace;
     }
 
     @media(max-width: 420px) {
-      h2 {
+      h3 {
         font-size: 1em;
       }
     }

--- a/frontend-ms/src/components/Layout/FooterComponent.vue
+++ b/frontend-ms/src/components/Layout/FooterComponent.vue
@@ -16,9 +16,14 @@
               <b-icon-github class="text-white"></b-icon-github>
             </a>
           </li>
-          <li>
+          <li class="me-3">
             <a href="https://x.com/magiodev/status/1800558963278201023" target="_blank" rel="noopener noreferrer">
               <b-icon-twitter class="text-white"></b-icon-twitter>
+            </a>
+          </li>
+          <li>
+            <a href="https://discord.gg/madscientists" target="_blank" rel="noopener noreferrer">
+              <b-icon-discord class="text-white"></b-icon-discord>
             </a>
           </li>
         </ul>

--- a/frontend-ms/src/views/Home.vue
+++ b/frontend-ms/src/views/Home.vue
@@ -11,14 +11,14 @@
       </div>
     </div>
 
-    <div class="row game">
+    <div class="row game" v-if="!isCountingDownToStart">
       <div class="col">
         <StatsComponent/>
         <PotsComponent class="mt-lg-5 mt-3 mb-lg-5"/>
       </div>
     </div>
 
-    <div class="row bet position-relative bg-pp-color-3">
+    <div class="row bet position-relative bg-pp-color-3" v-if="!isCountingDownToStart">
       <div class="col py-3 py-lg-5">
         <BidComponent/>
       </div>

--- a/frontend/src/components/Common/TimerComponent.vue
+++ b/frontend/src/components/Common/TimerComponent.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="timer-component offset-md-1 col-md-10 offset-lg-2 col-lg-8 offset-xl-3 col-xl-6 position-relative">
     <div class="timer-card text-center py-5">
-      <template v-if="timeLeftSeconds">
-        <h4 class="text-pp-purple-2">Game Ends: {{ new Date(gameState.end_time * 1000).toLocaleString() }}</h4>
-        <div>
-          <img class="skull me-2 d-inline" :src="imageSkull" alt="Skull"/>
-          <h2 class="text-pp-purple-2 d-inline">{{ timeLeftHuman }}</h2>
-          <h4>Extend count: {{gameState.extend_count}}</h4>
-        </div>
-      </template>
-      <div v-else>
-        <h2 class="text-pp-color-4">Time's up!</h2>
-        <p class="text-pp-color-4">Check the results in the section below.</p>
+      <h4 v-if="!isCountingDownToStart" class="text-pp-purple-2">Game Ends:
+        {{ new Date(gameState.end_time * 1000).toLocaleString() }}</h4>
+      <h4 v-else class="text-pp-purple-2">Game Starts Soon</h4>
+      <div>
+        <img class="skull me-2 d-inline" :src="imageSkull" alt="Skull"/>
+        <h2 class="text-pp-purple-2 d-inline">
+          <span v-if="isCountingDownToStart">Next round in:<br></span>
+          {{ timeLeftHuman }}
+        </h2>
+        <h4>Extend count: {{ gameState.extend_count }}</h4>
       </div>
     </div>
   </div>
 </template>
+
 
 <script>
 import {mapGetters} from "vuex";
@@ -50,6 +50,7 @@ export default {
     font-size: 2.5em;
     vertical-align: bottom;
   }
+
   h4 {
     font-size: 1.5em;
   }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -11,14 +11,14 @@
       </div>
     </div>
 
-    <div class="row game">
+    <div class="row game" v-if="!isCountingDownToStart">
       <div class="col">
         <StatsComponent/>
         <PotsComponent class="mt-lg-5 mt-3 mb-lg-5"/>
       </div>
     </div>
 
-    <div class="row bet position-relative bg-pp-color-5">
+    <div class="row bet position-relative bg-pp-color-5" v-if="!isCountingDownToStart">
       <div class="col py-3 py-lg-5">
         <BidComponent/>
       </div>

--- a/schema/prudent-pots.json
+++ b/schema/prudent-pots.json
@@ -12,12 +12,24 @@
     "properties": {
       "config": {
         "$ref": "#/definitions/GameConfig"
+      },
+      "next_game_start": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "uint64",
+        "minimum": 0.0
       }
     },
     "additionalProperties": false,
     "definitions": {
       "Addr": {
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
         "type": "string"
       },
       "GameConfig": {
@@ -30,6 +42,7 @@
           "game_cw721_addrs",
           "game_denom",
           "game_duration",
+          "game_duration_epoch",
           "game_end_threshold",
           "game_extend",
           "min_pot_initial_allocation",
@@ -37,7 +50,7 @@
         ],
         "properties": {
           "decay_factor": {
-            "$ref": "#/definitions/Uint128"
+            "$ref": "#/definitions/Decimal"
           },
           "fee": {
             "type": "integer",
@@ -62,6 +75,11 @@
             "type": "string"
           },
           "game_duration": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "game_duration_epoch": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0
@@ -179,6 +197,14 @@
           "game_end": {
             "type": "object",
             "properties": {
+              "next_game_start": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
               "raffle_cw721_token_addr": {
                 "type": [
                   "string",
@@ -203,6 +229,10 @@
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
         "type": "string"
       },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
         "type": "string"
@@ -216,7 +246,7 @@
           "decay_factor": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Uint128"
+                "$ref": "#/definitions/Decimal"
               },
               {
                 "type": "null"
@@ -262,6 +292,14 @@
             ]
           },
           "game_duration": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "game_duration_epoch": {
             "type": [
               "integer",
               "null"
@@ -616,6 +654,10 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         },
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+          "type": "string"
+        },
         "GameConfig": {
           "type": "object",
           "required": [
@@ -626,6 +668,7 @@
             "game_cw721_addrs",
             "game_denom",
             "game_duration",
+            "game_duration_epoch",
             "game_end_threshold",
             "game_extend",
             "min_pot_initial_allocation",
@@ -633,7 +676,7 @@
           ],
           "properties": {
             "decay_factor": {
-              "$ref": "#/definitions/Uint128"
+              "$ref": "#/definitions/Decimal"
             },
             "fee": {
               "type": "integer",
@@ -658,6 +701,11 @@
               "type": "string"
             },
             "game_duration": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "game_duration_epoch": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -84,6 +84,14 @@
         "game_end": {
           "type": "object",
           "properties": {
+            "next_game_start": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "raffle_cw721_token_addr": {
               "type": [
                 "string",
@@ -108,6 +116,10 @@
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
     },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
@@ -121,7 +133,7 @@
         "decay_factor": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Uint128"
+              "$ref": "#/definitions/Decimal"
             },
             {
               "type": "null"
@@ -167,6 +179,14 @@
           ]
         },
         "game_duration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "game_duration_epoch": {
           "type": [
             "integer",
             "null"

--- a/schema/raw/instantiate.json
+++ b/schema/raw/instantiate.json
@@ -8,12 +8,24 @@
   "properties": {
     "config": {
       "$ref": "#/definitions/GameConfig"
+    },
+    "next_game_start": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
     }
   },
   "additionalProperties": false,
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
     "GameConfig": {
@@ -26,6 +38,7 @@
         "game_cw721_addrs",
         "game_denom",
         "game_duration",
+        "game_duration_epoch",
         "game_end_threshold",
         "game_extend",
         "min_pot_initial_allocation",
@@ -33,7 +46,7 @@
       ],
       "properties": {
         "decay_factor": {
-          "$ref": "#/definitions/Uint128"
+          "$ref": "#/definitions/Decimal"
         },
         "fee": {
           "type": "integer",
@@ -58,6 +71,11 @@
           "type": "string"
         },
         "game_duration": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "game_duration_epoch": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/schema/raw/response_to_game_config.json
+++ b/schema/raw/response_to_game_config.json
@@ -16,6 +16,10 @@
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
     },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    },
     "GameConfig": {
       "type": "object",
       "required": [
@@ -26,6 +30,7 @@
         "game_cw721_addrs",
         "game_denom",
         "game_duration",
+        "game_duration_epoch",
         "game_end_threshold",
         "game_extend",
         "min_pot_initial_allocation",
@@ -33,7 +38,7 @@
       ],
       "properties": {
         "decay_factor": {
-          "$ref": "#/definitions/Uint128"
+          "$ref": "#/definitions/Decimal"
         },
         "fee": {
           "type": "integer",
@@ -58,6 +63,11 @@
           "type": "string"
         },
         "game_duration": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "game_duration_epoch": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0


### PR DESCRIPTION
**Summary:**
This PR introduces the `next_start_time` feature in the `game_end` function, allowing future game start scheduling, while also allowing to distribute the previous round prizes without locking in funds unnecessarily. It includes necessary validations and a new test to ensure correct functionality.

**Details:**
1. **Feature Addition:**
   - Added optional `next_start_time` parameter to `game_end` for scheduling the next game at a future timestamp.

2. **Validations:**
   - Ensures game has not started (`ContractError::GameNotStarted`).
   - Ensures game is not still active (`ContractError::GameStillActive`).
   - Ensures game has not already ended (`ContractError::GameAlreadyEnded`).
   - Validates `next_start_time` is in the future.

3. **Testing:**
   - New test `test_game_end_future_works` verifies the correct handling of `next_start_time`.
   - Tests include scenarios for game not started, game still active, and game ended.